### PR TITLE
fix: implicit declaration of function 'rt_vsprintf'

### DIFF
--- a/rt_vsnprintf.c
+++ b/rt_vsnprintf.c
@@ -54,6 +54,7 @@
 
 #include <rtconfig.h>
 #include <rtdef.h>
+#include <rtthread.h>
 
 #ifndef RT_VER_NUM /* Doesn't use menuconfig */
 // 'ntoa' conversion buffer size, this must be big enough to hold one converted


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3a004f8f-9cc9-4974-9e27-6bf498a9bff3)
