### PR TITLE
fix:rt_vsnprintf.c:814:5: warning: floating constant truncated to zero [-Woverflow]

### DIFF
--- a/rt_vsnprintf.c
+++ b/rt_vsnprintf.c
@@ -245,7 +245,7 @@ typedef uint64_t double_uint_t;
 #define DOUBLE_EXPONENT_MASK 0x7FFU
 #define DOUBLE_BASE_EXPONENT 1023
 #define DOUBLE_MAX_SUBNORMAL_EXPONENT_OF_10 -308
-#define DOUBLE_MAX_SUBNORMAL_POWER_OF_10 1e-308
+#define DOUBLE_MAX_SUBNORMAL_POWER_OF_10 ((double)1e-308L)
 
 #else
 #error "Unsupported double type configuration"


### PR DESCRIPTION
scons -j32 编译生成警告packages/rt_vsnprintf_full-latest/rt_vsnprintf.c:814:5: warning: floating constant truncated to zero [-Woverflow]
![image1](https://github.com/user-attachments/assets/4765c5d2-7acf-4be5-ace0-3234352086d9)


原因：编译选项中加入 -fsingle-precision-constant，由于精度限制单精度，所以double修饰会强制变为单精度导致被截断
---
![image2](https://github.com/user-attachments/assets/e1e4f9d0-21cb-493d-81b4-089fdce33859)

解决办法：
---
参考gcc官方做法：
![1image3](https://github.com/user-attachments/assets/91a7bbfb-a2cd-4803-8d11-4dcaa1d73bf3)
